### PR TITLE
Fix use of hostapd_cli

### DIFF
--- a/etc/hostapd/hostapd.conf
+++ b/etc/hostapd/hostapd.conf
@@ -11,3 +11,5 @@ wpa_passphrase=rpi_ap_pass
 wpa_key_mgmt=WPA-PSK
 wpa_pairwise=TKIP
 rsn_pairwise=CCMP
+ctrl_interface=/var/run/hostapd
+ctrl_interface_group=0


### PR DESCRIPTION
These lines have been added to correct the use of **hostapd_cli**, and without this configuration, the utility can not be used.